### PR TITLE
Use HTML IMG tags for figures in the markdown files to control size

### DIFF
--- a/SystemModeler/README.md
+++ b/SystemModeler/README.md
@@ -40,6 +40,7 @@ Figure(
             x=Axis(min=1, max=2, unit="s"))}),
 ```
 <img src="8d098.png" alt="Figure" width=300 />
+
 ```
 Figure(
     title="Fixed y-range",

--- a/SystemModeler/README.md
+++ b/SystemModeler/README.md
@@ -7,6 +7,7 @@ model Test
 end Test;
 ```
 
+---
 ```
 Figure(
     title="Figure with no group",
@@ -16,6 +17,7 @@ Figure(
 ```
 <img src="4afa9.png" alt="Figure" width=300 />
 
+---
 ```
 Figure(
     title="Different x-axis range",
@@ -29,6 +31,7 @@ Figure(
 ```
 <img src="27b52.png" alt="Figure" width=300 />
 
+---
 ```
 Figure(
     title="Fixed x-range",
@@ -41,6 +44,7 @@ Figure(
 ```
 <img src="8d098.png" alt="Figure" width=300 />
 
+---
 ```
 Figure(
     title="Fixed y-range",
@@ -53,6 +57,7 @@ Figure(
 ```
 <img src="9335d.png" alt="Figure" width=300 />
 
+---
 ```
 Figure(
     title="Fixed y-range with changed unit",
@@ -65,6 +70,7 @@ Figure(
 ```
 <img src="719f3.png" alt="Figure" width=300 />
 
+---
 ```
 Figure(
     title="x(t) and (x(t), y(t))",
@@ -76,6 +82,7 @@ Figure(
 ```
 <img src="03671.png" alt="Figure" width=300 />
 
+---
 ```
 Figure(
     title="Preferred plot",
@@ -86,6 +93,7 @@ Figure(
 ```
 <img src="105c9.png" alt="Figure" width=300 />
 
+---
 ```
 Figure(
     title="Caption with plot and variable links",
@@ -105,6 +113,7 @@ Figure(
 ```
 <img src="b014d.png" alt="Figure" width=300 />
 
+---
 ```
 Figure(
     title="No legend",
@@ -122,6 +131,7 @@ Figure(
 ```
 <img src="e8011.png" alt="Figure" width=300 />
 
+---
 ```
 Figure(
     title="Autoscale x with changed unit",
@@ -134,6 +144,7 @@ Figure(
 ```
 <img src="e1bbb.png" alt="Figure" width=300 />
 
+---
 ```
 Figure(
     title="Another preferred plot",

--- a/SystemModeler/README.md
+++ b/SystemModeler/README.md
@@ -14,7 +14,7 @@ Figure(
     plots={
         Plot(curves={Curve(y=x)})})
 ```
-![Plot](4afa9.png)
+<img src="4afa9.png" alt="Figure" width=300 />
 
 ```
 Figure(
@@ -27,7 +27,7 @@ Figure(
             curves={Curve(y=y)},
             x=Axis(min=1000000, max=2000000, unit="us"))})
 ```
-![Plot](27b52.png)
+<img src="27b52.png" alt="Figure" width=300 />
 
 ```
 Figure(
@@ -39,7 +39,7 @@ Figure(
             curves={Curve(y=x)},
             x=Axis(min=1, max=2, unit="s"))}),
 ```
-![Plot](8d098.png)
+<img src="8d098.png" alt="Figure" width=300 />
 ```
 Figure(
     title="Fixed y-range",
@@ -50,7 +50,7 @@ Figure(
             curves={Curve(y=x)},
             y=Axis(min=-0.5, max=0.5, unit="m"))})
 ```
-![Plot](9335d.png)
+<img src="9335d.png" alt="Figure" width=300 />
 
 ```
 Figure(
@@ -62,7 +62,7 @@ Figure(
             curves={Curve(y=x)},
             y=Axis(min=-100, max=100, unit="cm"))})
 ```
-![Plot](719f3.png)
+<img src="719f3.png" alt="Figure" width=300 />
 
 ```
 Figure(
@@ -73,7 +73,7 @@ Figure(
         Plot(curves={Curve(y=x, legend="x(t)")}),
         Plot(curves={Curve(x=x, y=y, legend="(x(t), y(t))")})})
 ```
-![Plot](03671.png)
+<img src="03671.png" alt="Figure" width=300 />
 
 ```
 Figure(
@@ -83,7 +83,7 @@ Figure(
     plots={
         Plot(curves={Curve(y=x)})})
 ```
-![Plot](105c9.png)
+<img src="105c9.png" alt="Figure" width=300 />
 
 ```
 Figure(
@@ -102,7 +102,7 @@ Figure(
             x=Axis(unit="us"))},
     caption="A caption can have\nmultiple paragraphs and contaidifferent links and variable replacements. \nThe value of(variable:x) at the end of simulation is %{x}.\nPlot links:(plot:plot-x), %[first plot](plot:plot-x)\n Variable links:(variable:y), %[y(t)](variable:y)\n Modelica URI: %(modelica:/Modelica.Blocks), %[link](modelica:///Modelica.Blocks).\nGeneriURI: %(http://www.modelica.org), %[link](http://www.modelica.org")
 ```
-![Plot](b014d.png)
+<img src="b014d.png" alt="Figure" width=300 />
 
 ```
 Figure(
@@ -119,7 +119,7 @@ Figure(
             identifier="plot-y",
             curves={Curve(y=y, legend="")})})
 ```
-![Plot](e8011.png)
+<img src="e8011.png" alt="Figure" width=300 />
 
 ```
 Figure(
@@ -131,7 +131,7 @@ Figure(
             curves={Curve(y=x)},
             x=Axis(unit="ms"))})
 ```
-![Plot](e1bbb.png)
+<img src="e1bbb.png" alt="Figure" width=300 />
 
 ```
 Figure(
@@ -141,4 +141,4 @@ Figure(
     plots={
         Plot(curves={Curve(y=x)})})
 ```
-![Plot](c52eb.png)
+<img src="c52eb.png" alt="Figure" width=300 />


### PR DESCRIPTION
To me, making the images smaller results in a better balance between the figure source code and the SystemModeler results.